### PR TITLE
Add basic client-side reminder webapp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Para y Ejercítate</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Para y Ejercítate</h1>
+  </header>
+  <main>
+    <section id="timer-section">
+      <h2>Siguiente recordatorio en:</h2>
+      <div id="timer">40:00</div>
+      <div id="controls">
+        <button id="done-btn">Marcar como hecho</button>
+        <button id="postpone-btn">Posponer 5 minutos</button>
+      </div>
+      <div id="settings">
+        Intervalo (min): <input type="number" id="interval-input" min="1" value="40">
+        <button id="save-interval">Guardar</button>
+      </div>
+    </section>
+    <section id="exercises-section">
+      <h2>Ejercicios</h2>
+      <ul id="exercise-list"></ul>
+      <button id="add-exercise-btn">Agregar ejercicio</button>
+    </section>
+  </main>
+  <footer>
+    <button id="theme-toggle">Modo oscuro</button>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,152 @@
+const DEFAULT_INTERVAL = 40; // minutes
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+const timerEl = $('timer');
+const intervalInput = $('interval-input');
+const saveIntervalBtn = $('save-interval');
+const doneBtn = $('done-btn');
+const postponeBtn = $('postpone-btn');
+const exerciseListEl = $('exercise-list');
+const addExerciseBtn = $('add-exercise-btn');
+const themeToggleBtn = $('theme-toggle');
+
+let interval = parseInt(localStorage.getItem('interval'), 10) || DEFAULT_INTERVAL;
+let remaining = interval * 60; // seconds
+let timerId = null;
+
+intervalInput.value = interval;
+
+function loadExercises() {
+  const stored = localStorage.getItem('exercises');
+  if (stored) {
+    return JSON.parse(stored);
+  }
+  const initial = [
+    'Estiramiento lateral de cuello',
+    'Rotación suave de cuello',
+    'Retracción cervical',
+    'Movilidad de hombros',
+    'Estiramiento de brazos',
+  ];
+  localStorage.setItem('exercises', JSON.stringify(initial));
+  return initial;
+}
+
+let exercises = loadExercises();
+
+function saveExercises() {
+  localStorage.setItem('exercises', JSON.stringify(exercises));
+}
+
+function renderExercises() {
+  exerciseListEl.innerHTML = '';
+  exercises.forEach((ex, index) => {
+    const li = document.createElement('li');
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `ex-${index}`;
+    label.htmlFor = checkbox.id;
+    label.textContent = ex;
+    li.appendChild(checkbox);
+    li.appendChild(label);
+    exerciseListEl.appendChild(li);
+  });
+}
+
+function updateTimerDisplay() {
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  timerEl.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function tick() {
+  remaining -= 1;
+  if (remaining <= 0) {
+    notify();
+    restartTimer();
+  }
+  updateTimerDisplay();
+}
+
+function startTimer() {
+  if (timerId) return;
+  timerId = setInterval(tick, 1000);
+}
+
+function stopTimer() {
+  clearInterval(timerId);
+  timerId = null;
+}
+
+function restartTimer() {
+  remaining = interval * 60;
+  document.querySelectorAll('#exercise-list input').forEach(cb => (cb.checked = false));
+}
+
+function notify() {
+  if (Notification.permission === 'granted') {
+    new Notification('¡Hora de ejercitar!', { body: 'Realiza tus ejercicios cervicales.' });
+  } else {
+    alert('¡Hora de ejercitar!');
+  }
+}
+
+saveIntervalBtn.addEventListener('click', () => {
+  const value = parseInt(intervalInput.value, 10);
+  if (value > 0) {
+    interval = value;
+    localStorage.setItem('interval', interval);
+    restartTimer();
+    updateTimerDisplay();
+  }
+});
+
+doneBtn.addEventListener('click', () => {
+  restartTimer();
+  updateTimerDisplay();
+});
+
+postponeBtn.addEventListener('click', () => {
+  remaining += 300; // 5 minutes
+  updateTimerDisplay();
+});
+
+addExerciseBtn.addEventListener('click', () => {
+  const name = prompt('Nombre del ejercicio:');
+  if (name) {
+    exercises.push(name);
+    saveExercises();
+    renderExercises();
+  }
+});
+
+themeToggleBtn.addEventListener('click', () => {
+  document.body.classList.toggle('dark');
+  const dark = document.body.classList.contains('dark');
+  themeToggleBtn.textContent = dark ? 'Modo claro' : 'Modo oscuro';
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
+});
+
+function applyTheme() {
+  const theme = localStorage.getItem('theme');
+  if (theme === 'dark') {
+    document.body.classList.add('dark');
+    themeToggleBtn.textContent = 'Modo claro';
+  }
+}
+
+function init() {
+  renderExercises();
+  applyTheme();
+  updateTimerDisplay();
+  startTimer();
+  if (Notification.permission !== 'granted' && Notification.permission !== 'denied') {
+    Notification.requestPermission();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,41 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+header, footer {
+  background-color: #4a90e2;
+  color: #fff;
+  text-align: center;
+  padding: 1em;
+}
+
+main {
+  padding: 1em;
+  max-width: 600px;
+  margin: auto;
+}
+
+#timer {
+  font-size: 3em;
+  text-align: center;
+  margin: 0.5em 0;
+}
+
+button {
+  padding: 0.5em 1em;
+  margin: 0.5em;
+  font-size: 1em;
+}
+
+.dark {
+  background-color: #222;
+  color: #eee;
+}
+
+.dark header, .dark footer {
+  background-color: #333;
+}


### PR DESCRIPTION
## Summary
- implement initial HTML layout with timer, exercises and settings
- style page with light/dark themes
- add JavaScript timer, notifications and localStorage persistence

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688244929a408326bb02ce7a4570b8dc